### PR TITLE
Chores

### DIFF
--- a/ivory-backend-c/src/Ivory/Compile/C/CmdlineFrontend.hs
+++ b/ivory-backend-c/src/Ivory/Compile/C/CmdlineFrontend.hs
@@ -37,6 +37,8 @@ import           System.Directory                        (createDirectoryIfMissi
 import           System.Environment                      (getArgs)
 import           System.FilePath                         (addExtension, (</>))
 
+import qualified Data.Maybe
+
 -- Code Generation Front End ---------------------------------------------------
 
 compile :: [Module] -> [Located Artifact] -> IO ()
@@ -73,7 +75,10 @@ stdoutmodules cmodules =
 outputmodules :: Opts -> [C.CompileUnits] -> [Located Artifact] -> IO ()
 outputmodules opts cmodules user_artifacts = do
   -- Irrrefutable pattern checked above
-  let Just srcdir = outDir opts
+  let srcdir =
+        Data.Maybe.fromMaybe
+          (error "Impossible")
+          $ outDir opts
   let incldir = hdrDir srcdir
   let rootdir = rootDir srcdir
   createDirectoryIfMissing True rootdir

--- a/ivory-model-check/src/Ivory/ModelCheck/Monad.hs
+++ b/ivory-model-check/src/Ivory/ModelCheck/Monad.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -214,8 +215,9 @@ snapshotRefs :: ModelCheck ()
 snapshotRefs = do
   rs <- getRefs
   b  <- symCond <$> get
-  forM_ (M.toList rs) $ \ ((t,r),[v]) ->
-    updateStReturnRef t r b v
+  forM_ (M.toList rs) $ \case
+    ((t,r),[v]) -> updateStReturnRef t r b v
+    x -> error $ "Expected ((t, r), [v]) but got " <> show x
 
 getStructs :: ModelCheck (M.Map I.Sym I.Struct)
 getStructs = do
@@ -230,7 +232,7 @@ addStruct s = do
              I.Abstract n _ -> n
   let st' = st { symStructs = M.insert nm s (symStructs st) }
   set st'
-  
+
 updateStRef :: I.Type -> Var -> Var -> ModelCheck ()
 updateStRef t v v' =
   sets_ (\st -> st { symRefs = M.insert (t,v) [v'] (symRefs st) })

--- a/ivory-model-check/test/Test.hs
+++ b/ivory-model-check/test/Test.hs
@@ -79,32 +79,36 @@ testArgs :: Args
 testArgs = initArgs { printQuery = False, printEnv = False }
 
 mkSuccess :: Def p -> [Module] -> TestTree
-mkSuccess d@(~(I.DefProc p)) mods = testCase (I.procSym p) $ do
+mkSuccess d@(I.DefProc p) mods = testCase (I.procSym p) $ do
   r <- modelCheck testArgs mods d
   let msg = printf "Expected: Safe\nActual: %s"
             (showResult r)
   assertBool msg (isSafe r)
+mkSuccess _ _ = error "Absurd"
 
 mkSuccessInline :: Def p -> [Module] -> TestTree
-mkSuccessInline d@(~(I.DefProc p)) mods = testCase (I.procSym p) $ do
+mkSuccessInline d@(I.DefProc p) mods = testCase (I.procSym p) $ do
   r <- modelCheck (testArgs { inlineCall = True }) mods d
   let msg = printf "Expected: Safe\nActual: %s"
             (showResult r)
   assertBool msg (isSafe r)
+mkSuccessInline _ _ = error "Absurd"
 
 mkFailure :: Def p -> [Module] -> TestTree
-mkFailure d@(~(I.DefProc p)) mods = testCase (I.procSym p) $ do
+mkFailure d@(I.DefProc p) mods = testCase (I.procSym p) $ do
   r <- modelCheck testArgs mods d
   let msg = printf "Expected: Unsafe\nActual: %s"
             (showResult r)
   assertBool msg (isUnsafe r)
+mkFailure _ _ = error "Absurd"
 
 mkNotError :: Def p -> [Module] -> TestTree
-mkNotError d@(~(I.DefProc p)) mods = testCase (I.procSym p) $ do
+mkNotError d@(I.DefProc p) mods = testCase (I.procSym p) $ do
   r <- modelCheck testArgs mods d
   let msg = printf "Expected: anything but Error\nActual: %s"
             (showResult r)
   assertBool msg (not $ isError r)
+mkNotError _ _ = error "Absurd"
 
 --------------------------------------------------------------------------------
 -- test modules

--- a/ivory-opts/src/Ivory/Opts/CFG.hs
+++ b/ivory-opts/src/Ivory/Opts/CFG.hs
@@ -29,7 +29,9 @@ import qualified Ivory.Language.Syntax.AST  as I
 import qualified Ivory.Language.Syntax.Type as I
 import qualified Data.Graph.Inductive as G
 
+#if !MIN_VERSION_base(4,18,0)
 import Control.Applicative (liftA2)
+#endif
 import System.FilePath
 import Data.Maybe
 import Data.List (find,(\\))

--- a/ivory-opts/src/Ivory/Opts/CSE.hs
+++ b/ivory-opts/src/Ivory/Opts/CSE.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE DeriveTraversable    #-}
 {-# LANGUAGE FlexibleContexts     #-}
 {-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE TypeOperators        #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Ivory.Opts.CSE (cseFold) where
@@ -20,6 +21,7 @@ import qualified Data.IntSet           as IntSet
 import           Data.List             (sort)
 import           Data.Map.Strict       (Map)
 import qualified Data.Map.Strict       as Map
+import qualified Data.Maybe
 import           Data.Reify
 import           Ivory.Language.Array  (ixRep)
 import qualified Ivory.Language.Syntax as AST
@@ -390,6 +392,11 @@ reconstruct (Graph subexprs root) = D.toList rootBlock
   (_, remap, (_, blockFacts)) =
     foldr (dedup usedOnce) mempty
       $ subexprs ++ [ (constUnique c, constExpr c) | c <- [minBound..maxBound] ]
-  Just rootGen = IntMap.lookup (IntMap.findWithDefault root root remap) blockFacts
+  rootGen =
+    Data.Maybe.fromMaybe
+      (error "No root found")
+      $ IntMap.lookup
+          (IntMap.findWithDefault root root remap)
+          blockFacts
   (((), Bindings { unusedBindings = usedOnce }), rootBlock) =
     runM rootGen $ Bindings Map.empty IntSet.empty 0

--- a/ivory-opts/src/Ivory/Opts/CSE.hs
+++ b/ivory-opts/src/Ivory/Opts/CSE.hs
@@ -6,13 +6,16 @@
 {-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE TypeOperators        #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE CPP                  #-}
 
 module Ivory.Opts.CSE (cseFold) where
 
 import           Prelude               ()
 import           Prelude.Compat
 
+#if !MIN_VERSION_base(4,18,0)
 import           Control.Applicative   (liftA2)
+#endif
 import qualified Data.DList            as D
 import           Data.IntMap.Strict    (IntMap)
 import qualified Data.IntMap.Strict    as IntMap

--- a/ivory/ivory.cabal
+++ b/ivory/ivory.cabal
@@ -87,7 +87,7 @@ library
                         containers >= 0.5,
                         monadLib >= 3.7,
                         template-haskell >= 2.8 && <3,
-                        th-abstraction >=0.3 && <0.5,
+                        th-abstraction >=0.3,
                         filepath,
                         text,
                         dlist >= 0.5,

--- a/ivory/src/Ivory/Language/BitData/BitData.hs
+++ b/ivory/src/Ivory/Language/BitData/BitData.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ConstraintKinds #-}

--- a/ivory/src/Ivory/Language/String.hs
+++ b/ivory/src/Ivory/Language/String.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE FlexibleContexts #-}
 
 module Ivory.Language.String where


### PR DESCRIPTION
Mostly `-Wincomplete-uni-patterns` and some `TypeOperators` warnings fixed.

The last remaining are coming from TH splices https://github.com/mainland/language-c-quote/pull/94